### PR TITLE
changed optim.parsimony for pratchet, added acctran, changed optNni f…

### DIFF
--- a/biblioTJ.bib
+++ b/biblioTJ.bib
@@ -14804,6 +14804,16 @@
   url = {http://www.jstor.org/stable/2289457}
 }
 
+@ARTICLE{Tavare1986,
+    author = {Tavar\'{e}, Simon},
+    title = {Some probabilistic and statistical problems in the analysis of DNA sequences}, 
+    journal= {Lectures on Mathematics in the Life Sciences}, 
+    number = {17}, 
+    pages = {57--86}, 
+    year = {1986},
+    publisher = {American Mathematical Society} 
+}
+
 @ARTICLE{tj789,
   author = {S. Tavaré and D. J. Balding and R. C. Griffiths and P. Donnelly},
   title = {Inferring coalescence times from DNA sequence data.},

--- a/phylo-practical.Rnw
+++ b/phylo-practical.Rnw
@@ -603,13 +603,16 @@ parsimony(tre.ini, dna2)
 @
 Then, optimization of the parsimony is achieved by:
 <<>>=
-tre.pars <- optim.parsimony(tre.ini, dna2)
+tre.pars <- pratchet(dna2, start=tre.ini, trace=0)
+parsimony(tre.pars, dna2)
 tre.pars
 @
 
 Here, the final result is very close to the original tree.
-The obtained tree is unrooted and does not have branch lengths, but it can be plotted as previously:
+The obtained tree is unrooted and does not have branch lengths. We add branch lengths proportional to the number of substitution with the function \texttt{acctran}.  
+It can be plotted as previously:
 <<out.width="\\textwidth">>=
+tre.pars <- acctran(tre.pars, dna2)
 plot(tre.pars, type="unr", show.tip=FALSE, edge.width=2)
 title("Maximum-parsimony tree")
 tiplabels(tre.pars$tip.label, bg=transp(num2col(annot$year, col.pal=myPal),.7),
@@ -722,13 +725,12 @@ fit.ini
 @
 
 \noindent We now have all the information needed for seeking a maximum likelihood solution using
-\texttt{optim.pml}; we specify that we want to optimize tree topology (\texttt{optNni=TRUE}), base
-frequencies (\texttt{optBf=TRUE}), the rates of all possible subtitutions (\texttt{optQ=TRUE}),
+\texttt{optim.pml}; we specify that we want to optimize tree topology (\texttt{rearrangement="stochastic"}), use a "GTR" model \cite{Tavare1986}, optimize base frequencies and the rates of all possible subtitutions,
 and use a gamma distribution to model variation in the substitution rates across
 sites (\texttt{optGamma=TRUE}):
 <<echo=TRUE, results='hide'>>=
-fit <- optim.pml(fit.ini, optNni=TRUE, optBf=TRUE,
-                 optQ=TRUE, optGamma=TRUE)
+fit <- optim.pml(fit.ini, rearrangement="stochastic", model="GTR", 
+    optGamma=TRUE)
 @
 <<>>=
 fit


### PR DESCRIPTION
Hi @thibautjombart, 
I changed a few things. `pratchet` is preferred over `optim.parsimony` as it may find better trees. Similar there is an additional "newish" argument `rearrangement` for the function `optim.pml`, which allows to choose between different criteria (so far "nni" and "stochastic"). Again "stochastic" may finds better trees, but is slower. As the example is small so there is no difference here. Additionally using the 'model' argument gives more control and is shorter to write. 
Cheers, 
Klaus
